### PR TITLE
check_bandwidth: output in a format supported by perfdata.

### DIFF
--- a/check_bandwidth.sh
+++ b/check_bandwidth.sh
@@ -71,7 +71,8 @@ rx_bps=$((rx2 - rx1))
 tx_kbps=$((tx_bps / 1024))
 rx_kbps=$((rx_bps / 1024))
 
-status="tx $1: $tx_kbps kb/s | rx $1: $rx_kbps kb/s"
+status="tx ${interface}: $tx_kbps kb/s, rx ${interface}: $rx_kbps kb/s | tx=$tx_kbps rx=$rx_kbps"
+
 if [[ $rx_kbps -ge $warning ]] || [[ $tx_kbps -ge $warning ]]; then
   if [[ $rx_kbps -ge $critical ]] || [[ $tx_kbps -ge $critical ]]; then
     exit_status=2


### PR DESCRIPTION
When the output status has a "pipe", followed by data formatted as "variable=val", nagios/icinga will interpret this as performance data which can be sent to a graphing system. For example, in icinga2, I forward the perfdata to graphite, then use grafana to draw graphics.

Example: https://www.bidon.ca/files/tmp/icinga2-bw-grafana.jpg

Thanks for this plugin :)