### PR TITLE
check_memcached: add description of bytes counters

### DIFF
--- a/check_memcached.sh
+++ b/check_memcached.sh
@@ -66,6 +66,9 @@ bytes=$(echo "$output" | grep ' bytes ' | awk '{ gsub(/\r/, ""); print $3 }')
 get_hits=$(echo "$output" | grep 'get_hits' | awk '{ gsub(/\r/, ""); print $3 }')
 get_misses=$(echo "$output" | grep 'get_misses' | awk '{ gsub(/\r/, ""); print $3 }')
 
+# limit_maxbytes = Number of bytes this server is permitted to use for storage.
+# bytes = Current number of bytes used by this server to store items.
+
 if [[ -z $limit_maxbytes ]] || [[ -z $bytes ]]; then
   echo "CRITICAL - 'limit_maxbytes' and 'bytes' are empty"
   exit 2


### PR DESCRIPTION
Hi!

Thanks for a good place to start with monitoring memcached :)

I had to look around a little to try to figure out what these metrics meant and what it would be alerting on. So to save someone else from looking this up - add what those metrics mean to the check.

Source:

https://dev.mysql.com/doc/refman/5.5/en/ha-memcached-stats-general.html